### PR TITLE
RadarrSync-6 Would you consider making this more generic?

### DIFF
--- a/Config.txt
+++ b/Config.txt
@@ -6,7 +6,7 @@ key = FCKGW-RHQQ2-YXRKT-8TG6W-2B7Q8
 [Radarr4k]
 url = http://127.0.0.1:8080
 key = FCKGW-RHQQ2-YXRKT-8TG6W-2B7Q8
-
+profile = 5
 
 
 


### PR DESCRIPTION
Addresses the request, now supports more than one radarr server.

Requires users to add a new property to the Config.txt.  Previous installs will need to be updated, new installs will get it preconfigured to sync 4k.

Example - Syncs  HD 720/1080p to another server
```
#Profile ID to sync from the source server to this server
profile = 6
```

Example - Syncs  UHD 4K to another server
```
#Profile ID to sync from the source server to this server
profile = 5
```