### PR TITLE
Improving profile handling

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,4 +1,4 @@
 todo:
   keyword: ['@todo', 'TODO']
   body: ['@body', 'BODY']
-  label: 'Enhancement'
+  label: 'enhancement'

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,4 @@
+todo:
+  keyword: ['@todo', 'TODO']
+  body: ['@body', 'BODY']
+  label: 'Enhancement'

--- a/RadarrSync.py
+++ b/RadarrSync.py
@@ -4,9 +4,10 @@ import requests
 import json
 import configparser
 import sys
+from bs4 import BeautifulSoup
 
-
-DEV = False
+DEV = True
+WHAT_IF = True
 
 ########################################################################################################################
 logger = logging.getLogger()
@@ -36,10 +37,59 @@ def ConfigSectionMap(section):
             dict1[option] = None
     return dict1
 
+# uses a private api call to get the profile information may be broken one day
+def validateProfile(root_url, api, profileName):
+    with requests.Session() as session:
+        session.trust_env = False
+        headers = {
+            'X-Api-Key': api,
+            'Referer': '{0}/settings/profiles'.format(root_url)
+        }
+        profiles = session.get('http://192.168.2.4:9004/api/profile', headers=headers).json()
+    try:
+        profileNum = int(profileName)
+    #if isinstance(profileName, int):  # check and see if were given the profile number or the profle name
+        if profileNum in range(1, len(profiles)+1):
+            logger.debug('user supplied profile number ({0}) found on server'.format(profileName))
+            return profileNum  # profile existsso return the ID to be consistant with value returned when a profile name supplied
+        else:
+            logger.warning('user supplied profile number ({0}) not found on server'.format(profileName))
+            return False
+    except:
+    #else:
+        for i in range(0, len(profiles)):
+            if profiles[i]['name'] == profileName:
+                logger.debug('{0} is profile {1}'.format(profiles[i]['name'], i + 1))
+                return i + 1  # validated the profile is on the server so return the ID number
+    logger.warning('user supplied profile name ({0}) not found on server'.format(profileName))
+    return False  # Terrible catch all statement, didn't find the profile any other way
+
+
+# @todo save profiles to config
+# @body write the list of profiles back to the config file or add a command argument so people can check them
+# listProfiles(SyncServer_url, SyncServer_key)  # gets a list of profiles from the server
+# uses a private api call to get the profile information may be broken one day
+def listProfiles(root_url, api):
+    profileList = []
+    with requests.Session() as session:
+        session.trust_env = False
+        headers = {
+            'X-Api-Key': api,
+             'Referer': '{0}/settings/profiles'.format(root_url)
+        }
+        profiles = session.get('{0}/api/profile'.format(root_url), headers=headers).json()
+        for i in range(0, len(profiles)):
+            logger.debug('{0} is profile {1}'.format(profiles[i]['name'], i+1))
+            profileList.append({i+1: profiles[i]['name']})
+    print(profileList)
+    return profileList
+
+
+# ---------------------------------------------Main Script-------------------------------------------------------------#
 
 Config = configparser.ConfigParser()
 
-# Loads an alternate config file so that I can work on my servers without uploading config to github
+# Loads an alternate config file so that I can work on my servers without uploading my personal config to github
 if DEV:
     settingsFilename = os.path.join(os.getcwd(), 'Dev'
                                                  'Config.txt')
@@ -47,6 +97,7 @@ else:
     settingsFilename = os.path.join(os.getcwd(), 'Config.txt')
 Config.read(settingsFilename)
 
+# Build primary server URLs and retrieve a json object of the primary server movies
 radarr_url = ConfigSectionMap("Radarr")['url']
 radarr_key = ConfigSectionMap("Radarr")['key']
 radarrSession = requests.Session()
@@ -56,27 +107,33 @@ if radarrMovies.status_code != 200:
     logger.error('Radarr server error - response {}'.format(radarrMovies.status_code))
     sys.exit(0)
 
+
+# MultiServer support, iterates through the config file syncing to multiple radarr servers STILL A ONE WAY SYNC
 for server in Config.sections():
 
     if server == 'Default' or server == "Radarr":
-        continue  # Default section handled previously as it always needed
+        continue  # Default/primary server section handled previously as it always needed so break out of the loop
 
     else:
         logger.debug('syncing to {0}'.format(server))
-
         session = requests.Session()
         session.trust_env = False
         SyncServer_url = ConfigSectionMap(server)['url']
         SyncServer_key = ConfigSectionMap(server)['key']
+        SyncServer_profile = validateProfile(SyncServer_url, SyncServer_key, ConfigSectionMap(server)['profile'])
         SyncServerMovies = session.get('{0}/api/movie?apikey={1}'.format(SyncServer_url, SyncServer_key))
         if SyncServerMovies.status_code != 200:
             logger.error('4K Radarr server error - response {}'.format(SyncServerMovies.status_code))
             sys.exit(0)
 
+        if WHAT_IF:
+            continue
+
+
     # build a list of movied IDs already in the sync server, this is used later to prevent readding a movie that already
     # exists.
     # TODO refactor variable names to make it clear this builds list of existing not list of movies to add
-    # TODO add reconcilliation to remove movies that have been deleted from source server
+    # TODO #11 Add reconciliation of sync server to primary server
     movieIds_to_syncserver = []
     for movie_to_sync in SyncServerMovies.json():
         movieIds_to_syncserver.append(movie_to_sync['tmdbId'])
@@ -85,7 +142,7 @@ for server in Config.sections():
     newMovies = 0
     searchid = []
     for movie in radarrMovies.json():
-        if movie['profileId'] == int(ConfigSectionMap(server)['profile']):
+        if movie['profileId'] == SyncServer_profile:
             if movie['tmdbId'] not in movieIds_to_syncserver:
                 logging.debug('title: {0}'.format(movie['title']))
                 logging.debug('qualityProfileId: {0}'.format(movie['qualityProfileId']))

--- a/RadarrSync.py
+++ b/RadarrSync.py
@@ -7,8 +7,13 @@ import sys
 from bs4 import BeautifulSoup
 
 DEV = True
+
+# TODO add way for users to see what would sync without syncing
+# @body I think the best way would be to create a sync report "Sync_Test.txt" or something like it
 WHAT_IF = True
 
+
+# TODO move log level into config file
 ########################################################################################################################
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -48,7 +53,6 @@ def validateProfile(root_url, api, profileName):
         profiles = session.get('http://192.168.2.4:9004/api/profile', headers=headers).json()
     try:
         profileNum = int(profileName)
-    #if isinstance(profileName, int):  # check and see if were given the profile number or the profle name
         if profileNum in range(1, len(profiles)+1):
             logger.debug('user supplied profile number ({0}) found on server'.format(profileName))
             return profileNum  # profile existsso return the ID to be consistant with value returned when a profile name supplied
@@ -56,7 +60,6 @@ def validateProfile(root_url, api, profileName):
             logger.warning('user supplied profile number ({0}) not found on server'.format(profileName))
             return False
     except:
-    #else:
         for i in range(0, len(profiles)):
             if profiles[i]['name'] == profileName:
                 logger.debug('{0} is profile {1}'.format(profiles[i]['name'], i + 1))
@@ -139,6 +142,7 @@ for server in Config.sections():
         movieIds_to_syncserver.append(movie_to_sync['tmdbId'])
         #logger.debug('found movie to be added')
 
+    # TODO Need better documentation on this section
     newMovies = 0
     searchid = []
     for movie in radarrMovies.json():
@@ -159,7 +163,7 @@ for server in Config.sections():
                            'qualityProfileId': movie['qualityProfileId'],
                            'titleSlug': movie['titleSlug'],
                            'tmdbId': movie['tmdbId'],
-                           'path': movie['path'],
+                           'path': movie['path'],  # TODO Consider adding support for user paths in config file
                            'monitored': movie['monitored'],
                            'images': images,
                            'profileId': movie['profileId'],

--- a/RadarrSync.py
+++ b/RadarrSync.py
@@ -55,13 +55,13 @@ def validateProfile(root_url, api, profileName):
         profileNum = int(profileName)
         if profileNum in range(1, len(profiles)+1):
             logger.debug('user supplied profile number ({0}) found on server'.format(profileName))
-            return profileNum  # profile existsso return the ID to be consistant with value returned when a profile name supplied
+            return profileNum  # profile exists so return the ID to be consistant with value returned when a profile name supplied
         else:
             logger.warning('user supplied profile number ({0}) not found on server'.format(profileName))
             return False
     except:
         for i in range(0, len(profiles)):
-            if profiles[i]['name'] == profileName:
+            if profiles[i]['name'].lower() == profileName.lower():
                 logger.debug('{0} is profile {1}'.format(profiles[i]['name'], i + 1))
                 return i + 1  # validated the profile is on the server so return the ID number
     logger.warning('user supplied profile name ({0}) not found on server'.format(profileName))
@@ -123,7 +123,10 @@ for server in Config.sections():
         session.trust_env = False
         SyncServer_url = ConfigSectionMap(server)['url']
         SyncServer_key = ConfigSectionMap(server)['key']
-        SyncServer_profile = validateProfile(SyncServer_url, SyncServer_key, ConfigSectionMap(server)['profile'])
+        SyncServer_profile = validateProfile(SyncServer_url, SyncServer_key, ConfigSectionMap(server)['profile'])  
+        if not SyncServer_profile:
+            logger.error('The profile provided was not found on {}'.format(server))
+            continue
         SyncServerMovies = session.get('{0}/api/movie?apikey={1}'.format(SyncServer_url, SyncServer_key))
         if SyncServerMovies.status_code != 200:
             logger.error('4K Radarr server error - response {}'.format(SyncServerMovies.status_code))

--- a/RadarrSync.py
+++ b/RadarrSync.py
@@ -6,7 +6,7 @@ import configparser
 import sys
 from bs4 import BeautifulSoup
 
-DEV = True
+DEV = True # If your are not Sperryfreak01 this should be False
 
 # TODO add way for users to see what would sync without syncing
 # @body I think the best way would be to create a sync report "Sync_Test.txt" or something like it

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.18.4
 configparser==3.5.0
+beautifulsoup4==4.6.3


### PR DESCRIPTION
Added a bunch of new profile handling code.

invalid profiles now gracefully handled, if an invalid profile is listed in the config the script will graceful handle it rather than crashing. If multiple servers are configured then an invalid profile will not stop other sync servers from being processed

Profiles can now be entered as the text listed in settings > profiles page in Radarr or as the profile number as before. This should maintain backwards comparability with existing config files.